### PR TITLE
Fix typo in licenses.astro

### DIFF
--- a/src/pages/licenses.astro
+++ b/src/pages/licenses.astro
@@ -116,7 +116,7 @@ const gridHeaderText = 'block text-[0.75rem] font-[600] leading-[120%] tracking-
             <span class={gridHeaderText}>Eventual OSS</span>
           </div>
           <div class="w-3/12 h-[100%] flex items-center">
-            <span class={gridHeaderText}>Feautre Complete</span>
+            <span class={gridHeaderText}>Feature Complete</span>
           </div>
           <div class="w-3/12 h-[100%] flex items-center">
             <span class={gridHeaderText}>Examples</span>


### PR DESCRIPTION
From `Feautre Complete` to `Feature Complete`