### PR TITLE
Fix: spelling "licence" to "license"

### DIFF
--- a/src/pages/licenses.astro
+++ b/src/pages/licenses.astro
@@ -68,7 +68,7 @@ const cardTitleClasses = `font-sans text-[1.375rem] font-[500] color-black leadi
       </div>
       <div class="w-12/12 lg:w-6/12 mb-[1.25rem] lg:pr-[0.72rem]">
         <div class={card}>
-          <a href="https://fcl.dev/" target="_BLANK"><h4 class={cardTitleClasses}><span class="mr-[0.69rem] font-[600]">Fair Core Licence (FCL)</span><svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 15 15" fill="none">
+          <a href="https://fcl.dev/" target="_BLANK"><h4 class={cardTitleClasses}><span class="mr-[0.69rem] font-[600]">Fair Core License (FCL)</span><svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 15 15" fill="none">
             <path d="M1 2H13M13 2V14M13 2L1 14" stroke="black" stroke-width="2.3"/></span>
             </svg></h4></a>
           <p>A simple non-compete license with two-year delayed conversion to Open Source. Consider it for monetizing self-hosted software.</p>


### PR DESCRIPTION
"License" in the FCL was mispelled. This PR uses "license" which matches usage throughout the rest of the website.